### PR TITLE
Update to url 1.0.0

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,6 +17,6 @@ readme = "README.md"
 
 [dependencies]
 sha1 = "0.1.1"
-url = "0.5.4"
+url = "1.0.0"
 rustc-serialize = "0.3.16"
 unix_socket = { version ="0.5.0", optional = true }

--- a/src/connection.rs
+++ b/src/connection.rs
@@ -20,29 +20,19 @@ use unix_socket::UnixStream;
 
 static DEFAULT_PORT: u16 = 6379;
 
-fn redis_scheme_type_mapper(scheme: &str) -> url::SchemeType {
-    match scheme {
-        "redis" => url::SchemeType::Relative(DEFAULT_PORT),
-        "unix" => url::SchemeType::FileLike,
-        _ => url::SchemeType::NonRelative,
-    }
-}
-
 /// This function takes a redis URL string and parses it into a URL
 /// as used by rust-url.  This is necessary as the default parser does
 /// not understand how redis URLs function.
-pub fn parse_redis_url(input: &str) -> url::ParseResult<url::Url> {
-    let mut parser = url::UrlParser::new();
-    parser.scheme_type_mapper(redis_scheme_type_mapper);
-    match parser.parse(input) {
+pub fn parse_redis_url(input: &str) -> RedisResult<url::Url> {
+    match url::Url::parse(input) {
         Ok(result) => {
-            if result.scheme == "redis" || result.scheme == "unix" {
+            if result.scheme() == "redis" || result.scheme() == "unix" {
                 Ok(result)
             } else {
-                Err(url::ParseError::InvalidScheme)
+                fail!((ErrorKind::InvalidClientConfig, "Redis URL did not parse"));
             }
         },
-        Err(err) => Err(err),
+        Err(_) => fail!((ErrorKind::InvalidClientConfig, "Redis URL did not parse")),
     }
 }
 
@@ -87,21 +77,18 @@ impl IntoConnectionInfo for ConnectionInfo {
 
 impl<'a> IntoConnectionInfo for &'a str {
     fn into_connection_info(self) -> RedisResult<ConnectionInfo> {
-        match parse_redis_url(self) {
-            Ok(u) => u.into_connection_info(),
-            Err(_) => fail!((ErrorKind::InvalidClientConfig, "Redis URL did not parse")),
-        }
+        parse_redis_url(self).and_then(|u| u.into_connection_info())
     }
 }
 
 fn url_to_tcp_connection_info(url: url::Url) -> RedisResult<ConnectionInfo> {
     Ok(ConnectionInfo {
         addr: Box::new(ConnectionAddr::Tcp(
-            unwrap_or!(url.serialize_host(),
-                fail!((ErrorKind::InvalidClientConfig, "Missing hostname"))),
+            unwrap_or!(url.host_str().into(),
+                fail!((ErrorKind::InvalidClientConfig, "Missing hostname"))).into(),
             url.port().unwrap_or(DEFAULT_PORT)
         )),
-        db: match url.serialize_path().unwrap_or("".to_string())
+        db: match url.path()
                 .trim_matches('/') {
             "" => 0,
             path => unwrap_or!(path.parse::<i64>().ok(),
@@ -118,8 +105,7 @@ fn url_to_unix_connection_info(url: url::Url) -> RedisResult<ConnectionInfo> {
             unwrap_or!(url.to_file_path().ok(),
                 fail!((ErrorKind::InvalidClientConfig, "Missing path"))),
         )),
-        db: match url.query_pairs().unwrap_or(vec![])
-                .into_iter().filter(|&(ref key, _)| key == "db").next() {
+        db: match url.query_pairs().filter(|&(ref key, _)| key == "db").next() {
             Some((_, db)) => unwrap_or!(db.parse::<i64>().ok(),
                 fail!((ErrorKind::InvalidClientConfig, "Invalid database number"))),
             None => 0,
@@ -136,9 +122,9 @@ fn url_to_unix_connection_info(_: url::Url) -> RedisResult<ConnectionInfo> {
 
 impl IntoConnectionInfo for url::Url {
     fn into_connection_info(self) -> RedisResult<ConnectionInfo> {
-        if self.scheme == "redis" {
+        if self.scheme() == "redis" {
             url_to_tcp_connection_info(self)
-        } else if self.scheme == "unix" {
+        } else if self.scheme() == "unix" {
             url_to_unix_connection_info(self)
         } else {
             fail!((ErrorKind::InvalidClientConfig, "URL provided is not a redis URL"));


### PR DESCRIPTION
rust-url v1.0.0 had some major breaking changes.
The biggest one was the change from struct members to getter methods
and the fact that the scheme mapper was removed.
With it, the `InvalidScheme` error was removed.

redis-rs used this to fail with schemes other than `redis` and `unix`.

I now changed the return type to a RedisResult, so we can handle the
error ourselves. It is only called at one position anyway.

`parse_redis_url` _is_ part of the publicly exposed API though, so
changing the return type is a breaking change.
